### PR TITLE
UIWebViewのloadDataメソッドの引数にnilを指定しているためwarningが発生している

### DIFF
--- a/NCMB/NCMBRichPush/NCMBRichPushView.m
+++ b/NCMB/NCMBRichPush/NCMBRichPushView.m
@@ -292,7 +292,7 @@ shouldStartLoadWithRequest:(NSURLRequest*) request
 
         NSString *html = @"<html><body><h1>ページを開けません。</h1></body></html>";
         NSData *bodyData = [html dataUsingEncoding:NSUTF8StringEncoding];
-        [self.wv loadData:bodyData MIMEType:@"text/html" textEncodingName:@"utf-8" baseURL:nil];
+        [self.wv loadData:bodyData MIMEType:@"text/html" textEncodingName:@"utf-8" baseURL:[[NSURL alloc]init]];
     }
 }
 


### PR DESCRIPTION
## 概要(Summary)

- Fixed #98 

## 動作確認手順(Step for Confirmation)

リッチプッシュからwebviewを表示
