### PR TITLE
Fix reference path about modulemap file.

### DIFF
--- a/NCMB.xcodeproj/project.pbxproj
+++ b/NCMB.xcodeproj/project.pbxproj
@@ -150,7 +150,7 @@
 		8AB2CF1C1CE32C1000F27481 /* NCMB_Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NCMB_Info.plist; sourceTree = "<group>"; };
 		99AE1ACB1F94B854005EA065 /* NCMBURLSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NCMBURLSession.h; path = NCMBURLSession/NCMBURLSession.h; sourceTree = "<group>"; };
 		99AE1ACC1F94B854005EA065 /* NCMBURLSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NCMBURLSession.m; path = NCMBURLSession/NCMBURLSession.m; sourceTree = "<group>"; };
-		9D305C6C1CEDAC990066BFE7 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		9D305C6C1CEDAC990066BFE7 /* NCMB.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = NCMB.modulemap; sourceTree = "<group>"; };
 		9D4B643A1ED42873008B015B /* NCMBDateFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCMBDateFormat.h; sourceTree = "<group>"; };
 		9D4B643B1ED42873008B015B /* NCMBDateFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCMBDateFormat.m; sourceTree = "<group>"; };
 		9DB041431EFCDD6E00BDEFFC /* NCMBRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCMBRequest.h; sourceTree = "<group>"; };
@@ -172,7 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				5D99270F1EA5FB21008F4319 /* NCMB_umbrella.h */,
-				9D305C6C1CEDAC990066BFE7 /* module.modulemap */,
+				9D305C6C1CEDAC990066BFE7 /* NCMB.modulemap */,
 				8AB2CDFD1CE3153F00F27481 /* NCMB */,
 				8AB2CDFC1CE3153F00F27481 /* Products */,
 			);


### PR DESCRIPTION
## Summary

This merge request fixes the wrong reference path(as below) about modulemap file.
![modumap_wrong_referencepath](https://user-images.githubusercontent.com/5669641/32412832-2d3919ba-c247-11e7-9ea2-6671a4af6e78.png)

## Step for Confirmation

Check the following screen capture and the commit. 
You will see the reference path has been changed to NCMB.modulemap correctly.
![modulemap_correct_referecepath](https://user-images.githubusercontent.com/5669641/32412883-432267da-c248-11e7-825d-7f5b9df2864d.png)
