### PR TITLE
Fix warning about discarding qualifiers

### DIFF
--- a/NCMB/NCMBError.h
+++ b/NCMB/NCMBError.h
@@ -18,7 +18,7 @@
 #import <Foundation/Foundation.h>
 
 /*! @abstract ncmb error domain */
-extern NSString const *kNCMBErrorDomain;
+extern NSString * const kNCMBErrorDomain;
 
 extern NSInteger const NCMBErrorFacebookLoginCancelled;
 

--- a/NCMB/NCMBError.m
+++ b/NCMB/NCMBError.m
@@ -17,7 +17,7 @@
 #import "NCMBError.h"
 
 
-NSString const *kNCMBErrorDomain = @"com.nifcloud.mbaas";
+NSString * const kNCMBErrorDomain = @"com.nifcloud.mbaas";
 
 NSInteger const NCMBErrorFacebookLoginCancelled = 401004;
 


### PR DESCRIPTION
## Summary

This pull request fixes #189.

## Step for Confirmation

I checked the warning has disappeared at local machine.
