### PR TITLE
fix userlogin with username or passwd contains special characters

### DIFF
--- a/NCMB/NCMBRequest/NCMBRequest.h
+++ b/NCMB/NCMBRequest/NCMBRequest.h
@@ -28,6 +28,11 @@
                     header:(NSDictionary *)headers
                       body:(NSDictionary *)body;
 
+-(instancetype)initWithURLStringForUser:(NSString *)urlString
+                    method:(NSString *)method
+                    header:(NSDictionary *)headers
+                      body:(NSDictionary *)body;
+
 -(instancetype)initWithURL:(NSURL *)url
                     method:(NSString *)method
                     header:(NSDictionary *)headers

--- a/NCMB/NCMBRequest/NCMBRequest.m
+++ b/NCMB/NCMBRequest/NCMBRequest.m
@@ -97,6 +97,25 @@ static NSString *const kOSVersionFieldName = @"X-NCMB-OS-Version";
     return [self initWithURL:url method:method header:headers bodyData:bodyData];
 }
 
+-(instancetype)initWithURLStringForUser:(NSString *)urlString
+                          method:(NSString *)method
+                          header:(NSDictionary *)headers
+                            body:(NSDictionary *)body
+{
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/%@",kEndPoint,kAPIVersion,urlString]];
+    NSData *bodyData = nil;
+    if (body != nil) {
+        NSError *error = nil;
+        bodyData = [NSJSONSerialization dataWithJSONObject:body
+                                                   options:kNilOptions
+                                                     error:&error];
+        if (error) {
+            [NSException raise:NSInvalidArgumentException format:@"body data is invalid json format."];
+        }
+    }
+    return [self initWithURL:url method:method header:headers bodyData:bodyData];
+}
+
 +(NSString *)returnTimeStamp{
     return [[NCMBDateFormat getIso8601DateFormat] stringFromDate:[NSDate date]];
 }

--- a/NCMB/NCMBUser.m
+++ b/NCMB/NCMBUser.m
@@ -664,14 +664,15 @@ static BOOL isEnableAutomaticUser = NO;
     //pathの作成
     NSString *path = @"";
     for (int i = 0; i< [sortedQueryArray count]; i++){
+        NSString * query = [sortedQueryArray[i] stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@"#[]@!&()*+,;\"<>\\%^`{|} \b\t\n\a\r"] invertedSet]];
         if (i == 0){
-            path = [path stringByAppendingString:[NSString stringWithFormat:@"%@", sortedQueryArray[i]]];
+            path = [path stringByAppendingString:[NSString stringWithFormat:@"%@", query]];
         } else {
-            path = [path stringByAppendingString:[NSString stringWithFormat:@"&%@", sortedQueryArray[i]]];
+            path = [path stringByAppendingString:[NSString stringWithFormat:@"&%@", query]];
         }
     }
     NSString *url = [NSString stringWithFormat:@"login?%@", path];
-    NCMBRequest *request = [[NCMBRequest alloc] initWithURLString:url
+    NCMBRequest *request = [[NCMBRequest alloc] initWithURLStringForUser:url
                                                            method:@"GET"
                                                            header:nil
                                                              body:nil];

--- a/NCMBTests/NCMBTests/NCMBUserSpec.m
+++ b/NCMBTests/NCMBTests/NCMBUserSpec.m
@@ -1445,6 +1445,43 @@ describe(@"NCMBUser", ^{
             }];
         });
     });
+         
+    it(@"logInWithUsernameInBackground passwd_special_char", ^{
+        NSDictionary *responseDic = @{ @"objectId" : @"09Mp23m4bEOInUqT",
+                                       @"mailAddress" : [NSNull null],
+                                       @"mailAddressConfirm" : [NSNull null],
+                                       @"sessionToken" : @"iXDIelJRY3ULBdms281VTmc5O",
+                                       @"updateDate" : @"2013-08-30T05:32:03.868Z",
+                                       @"userName" : @"NCMBUser",
+                                       @"key":@"value",
+                                       @"createDate" : @"2013-08-28T07:46:09.801Z"} ;
+
+        NSData *responseData = [NSJSONSerialization dataWithJSONObject:responseDic options:NSJSONWritingPrettyPrinted error:nil];
+
+        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+            NSString *query = @"password=test%21%22%23$%25%26'%28%29%2A%2B%2C-./:%3B%3C=%3E?%40%5B%5C%5D%5E_%60%7B%7C%7D~test&userName=NCMBUser";
+            return [request.URL.host isEqualToString:@"mbaas.api.nifcloud.com"] && [[request.URL query] isEqualToString:query];
+        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
+            return [OHHTTPStubsResponse responseWithData:responseData statusCode:201 headers:@{@"Content-Type":@"application/json;charset=UTF-8"}];
+        }];
+
+        waitUntil(^(DoneCallback done) {
+            [NCMBUser logInWithUsernameInBackground:@"NCMBUser" password:@"test!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~test" block:^(NCMBUser *user, NSError *error) {
+                expect(error).beNil();
+                expect(user.objectId).to.equal(@"09Mp23m4bEOInUqT");
+                expect(user.sessionToken).to.equal(@"iXDIelJRY3ULBdms281VTmc5O");
+                expect(user.userName).to.equal(@"NCMBUser");
+                expect([user objectForKey:@"key"]).to.equal(@"value");
+
+                NCMBUser *currentUser = NCMBUser.currentUser;
+                expect(currentUser.objectId).to.equal(@"09Mp23m4bEOInUqT");
+                expect(currentUser.sessionToken).to.equal(@"iXDIelJRY3ULBdms281VTmc5O");
+                expect(currentUser.userName).to.equal(@"NCMBUser");
+                expect([currentUser objectForKey:@"key"]).to.equal(@"value");
+                done();
+            }];
+        });
+    });
 
     it(@"logInWithUsernameInBackground error test", ^{
         NSDictionary *responseDic = @{ @"code" : @"E400000",


### PR DESCRIPTION
## 概要(Summary)

- Fixed #41 

## 動作確認手順(Step for Confirmation)

- Run the unit test
- Confirm operation
ユーザログイン
```
 [NCMBUser logInWithUsernameInBackground:@"test" password:@"!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" block:^(NCMBUser *user, NSError *error) {
        if (!error) {
            NSLog(@"ログイン成功");
        } else {
            NSLog(@"ログイン失敗: %@", error);
        }
    }];
```