### PR TITLE
Release prepare v3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode11.3
 xcode_workspace: NCMBTests/NCMBTests.xcworkspace
 xcode_scheme: NCMBTests
 xcode_sdk: iphonesimulator

--- a/NCMB.podspec
+++ b/NCMB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "NCMB"
-  s.version      = "3.0.4"
+  s.version      = "3.1.0"
   s.summary      = "NCMB is SDK for NIFCLOUD mobile backend."
   s.description  = <<-DESC
                    NCMB is SDK for NIFCLOUD mobile backend.
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.license      = "Apache License, Version 2.0"
   s.author       = "FUJITSU CLOUD TECHNOLOGIES LIMITED"
   s.platform     = :ios, "5.1"
-  s.source       = { :git => 'https://github.com/NIFCLOUD-mbaas/ncmb_ios.git', :tag => 'v3.0.4' }
+  s.source       = { :git => 'https://github.com/NIFCLOUD-mbaas/ncmb_ios.git', :tag => 'v3.1.0' }
   s.source_files  = "NCMB/**/*.{h,m,c}"
   s.frameworks = "Foundation", "UIKit", "MobileCoreServices", "AudioToolbox", "SystemConfiguration"
   s.requires_arc = true

--- a/NCMB/NCMBConstants.h
+++ b/NCMB/NCMBConstants.h
@@ -22,7 +22,7 @@
 
 #pragma mark - error
 #define ERRORDOMAIN @"NCMBErrorDomain"
-#define SDK_VERSION @"3.0.4"
+#define SDK_VERSION @"3.1.0"
 
 #define DATA_MAIN_PATH [NSHomeDirectory() stringByAppendingPathComponent:@"Library/"]
 #define COMMAND_CACHE_FOLDER_PATH [NSString stringWithFormat:@"%@/Private Documents/NCMB/Command Cache/", DATA_MAIN_PATH]

--- a/NCMB/NCMB_Info.plist
+++ b/NCMB/NCMB_Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.4</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/NCMBTests/NCMBTests/NCMBInstallationSpec.m
+++ b/NCMBTests/NCMBTests/NCMBInstallationSpec.m
@@ -54,7 +54,7 @@ describe(@"NCMBInstallation", ^{
                                                        },
                                                @"applicationName" : @"aaaa",
                                                @"objectId" : @"EVMu2ne7bjzZhOW2",
-                                               @"sdkVersion" : @"3.0.4"
+                                               @"sdkVersion" : @"3.1.0"
                                                };
 
     NSDictionary *responseInstallation = @{@"channels" : @[

--- a/NCMBTests/Podfile
+++ b/NCMBTests/Podfile
@@ -3,7 +3,7 @@ target :NCMBTests do
   pod 'Specta'
   pod 'Expecta'
   pod 'OCMock'
-  pod 'OHHTTPStubs'
+  pod 'OHHTTPStubs', '~> 8.0'   
   # pod 'OCHamcrest',  '~> 3.0'   # hamcrest matchers
   # pod 'OCMockito',   '~> 1.0'   # OCMock
   # pod 'LRMocky',     '~> 0.9'   # LRMocky

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@
 
 - iOS 10.x ～ iOS 13.x
 - Xcode 9.x ～ Xcode 11.x
-- armv7, armv7s, arm64アーキテクチャ
+- armv7s, arm64, arm64e アーキテクチャ
 - iOS/Xcodeのバージョンに依って対応が必要となる可能性があります。詳細はニフクラ mobile backendの[ドキュメント](https://mbaas.nifcloud.com/doc/current/)をご覧ください。
 
 ## テクニカルサポート窓口対応バージョン


### PR DESCRIPTION
## 概要(Summary)

- Fixed バージョン番号
- unit test 用ライブラリ固定、travis環境 xcodeを11.3に変更
- supportするarchitectureを更新
https://qiita.com/takkyun/items/814aa45beee422a5f0c6

## 動作確認手順(Step for Confirmation)

Run the unit test.
