### PR TITLE
Bump/v3.2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB.podspec
+++ b/NCMB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "NCMB"
-  s.version      = "3.1.2"
+  s.version      = "3.2.0"
   s.summary      = "NCMB is SDK for NIFCLOUD mobile backend."
   s.description  = <<-DESC
                    NCMB is SDK for NIFCLOUD mobile backend.

--- a/NCMB/NCMB.h
+++ b/NCMB/NCMB.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMB.m
+++ b/NCMB/NCMB.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBACL.h
+++ b/NCMB/NCMBACL.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBACL.m
+++ b/NCMB/NCMBACL.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBAnalytics.h
+++ b/NCMB/NCMBAnalytics.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBAnalytics.m
+++ b/NCMB/NCMBAnalytics.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBAnonymousUtils.h
+++ b/NCMB/NCMBAnonymousUtils.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBAnonymousUtils.m
+++ b/NCMB/NCMBAnonymousUtils.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBConstants.h
+++ b/NCMB/NCMBConstants.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBConstants.h
+++ b/NCMB/NCMBConstants.h
@@ -22,7 +22,7 @@
 
 #pragma mark - error
 #define ERRORDOMAIN @"NCMBErrorDomain"
-#define SDK_VERSION @"3.1.2"
+#define SDK_VERSION @"3.2.0"
 
 #define DATA_MAIN_PATH [NSHomeDirectory() stringByAppendingPathComponent:@"Library/"]
 #define COMMAND_CACHE_FOLDER_PATH [NSString stringWithFormat:@"%@/Private Documents/NCMB/Command Cache/", DATA_MAIN_PATH]

--- a/NCMB/NCMBDateFormat.h
+++ b/NCMB/NCMBDateFormat.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBDateFormat.m
+++ b/NCMB/NCMBDateFormat.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBError.h
+++ b/NCMB/NCMBError.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBError.m
+++ b/NCMB/NCMBError.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBFile.h
+++ b/NCMB/NCMBFile.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBFile.m
+++ b/NCMB/NCMBFile.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBGeoPoint.h
+++ b/NCMB/NCMBGeoPoint.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBGeoPoint.m
+++ b/NCMB/NCMBGeoPoint.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBInstallation.h
+++ b/NCMB/NCMBInstallation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBInstallation.m
+++ b/NCMB/NCMBInstallation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBObject+Subclass.h
+++ b/NCMB/NCMBObject+Subclass.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBObject.h
+++ b/NCMB/NCMBObject.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBObject.m
+++ b/NCMB/NCMBObject.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBPush.h
+++ b/NCMB/NCMBPush.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBPush.m
+++ b/NCMB/NCMBPush.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBQuery.h
+++ b/NCMB/NCMBQuery.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBQuery.m
+++ b/NCMB/NCMBQuery.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBReachability/NCMBReachability.h
+++ b/NCMB/NCMBReachability/NCMBReachability.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBReachability/NCMBReachability.m
+++ b/NCMB/NCMBReachability/NCMBReachability.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRelation.h
+++ b/NCMB/NCMBRelation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRelation.m
+++ b/NCMB/NCMBRelation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRequest/NCMBRequest.h
+++ b/NCMB/NCMBRequest/NCMBRequest.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRequest/NCMBRequest.m
+++ b/NCMB/NCMBRequest/NCMBRequest.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRichPush/NCMBCloseImageView.h
+++ b/NCMB/NCMBRichPush/NCMBCloseImageView.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRichPush/NCMBCloseImageView.m
+++ b/NCMB/NCMBRichPush/NCMBCloseImageView.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRichPush/NCMBRichPushView.h
+++ b/NCMB/NCMBRichPush/NCMBRichPushView.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRichPush/NCMBRichPushView.m
+++ b/NCMB/NCMBRichPush/NCMBRichPushView.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRole.h
+++ b/NCMB/NCMBRole.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBRole.m
+++ b/NCMB/NCMBRole.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBScript.h
+++ b/NCMB/NCMBScript.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBScript.m
+++ b/NCMB/NCMBScript.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBScriptService/NCMBScriptService.h
+++ b/NCMB/NCMBScriptService/NCMBScriptService.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBScriptService/NCMBScriptService.m
+++ b/NCMB/NCMBScriptService/NCMBScriptService.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBSubclassing.h
+++ b/NCMB/NCMBSubclassing.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBURLSession/NCMBURLSession.h
+++ b/NCMB/NCMBURLSession/NCMBURLSession.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBURLSession/NCMBURLSession.m
+++ b/NCMB/NCMBURLSession/NCMBURLSession.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBUser.h
+++ b/NCMB/NCMBUser.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMBUser.m
+++ b/NCMB/NCMBUser.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NCMB_Info.plist
+++ b/NCMB/NCMB_Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/NCMB/NSDataBase64Encode/NSDataBase64Encode.h
+++ b/NCMB/NSDataBase64Encode/NSDataBase64Encode.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/NSDataBase64Encode/NSDataBase64Encode.m
+++ b/NCMB/NSDataBase64Encode/NSDataBase64Encode.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBAddOperation.h
+++ b/NCMB/Operations/NCMBAddOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBAddOperation.m
+++ b/NCMB/Operations/NCMBAddOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBAddUniqueOperation.h
+++ b/NCMB/Operations/NCMBAddUniqueOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBAddUniqueOperation.m
+++ b/NCMB/Operations/NCMBAddUniqueOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBDeleteOperation.h
+++ b/NCMB/Operations/NCMBDeleteOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBDeleteOperation.m
+++ b/NCMB/Operations/NCMBDeleteOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBIncrementOperation.h
+++ b/NCMB/Operations/NCMBIncrementOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBIncrementOperation.m
+++ b/NCMB/Operations/NCMBIncrementOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBRelationOperation.h
+++ b/NCMB/Operations/NCMBRelationOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBRelationOperation.m
+++ b/NCMB/Operations/NCMBRelationOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBRemoveOperation.h
+++ b/NCMB/Operations/NCMBRemoveOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBRemoveOperation.m
+++ b/NCMB/Operations/NCMBRemoveOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBSetOperation.h
+++ b/NCMB/Operations/NCMBSetOperation.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/Operations/NCMBSetOperation.m
+++ b/NCMB/Operations/NCMBSetOperation.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/PrivateHeaders/NCMBObject+Private.h
+++ b/NCMB/PrivateHeaders/NCMBObject+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/PrivateHeaders/NCMBQuery+Private.h
+++ b/NCMB/PrivateHeaders/NCMBQuery+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/PrivateHeaders/NCMBRelation+Private.h
+++ b/NCMB/PrivateHeaders/NCMBRelation+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/PrivateHeaders/NCMBUser+Private.h
+++ b/NCMB/PrivateHeaders/NCMBUser+Private.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/SubClassHandler/SubClassHandler.h
+++ b/NCMB/SubClassHandler/SubClassHandler.h
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMB/SubClassHandler/SubClassHandler.m
+++ b/NCMB/SubClassHandler/SubClassHandler.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBAnonymousSpec.m
+++ b/NCMBTests/NCMBTests/NCMBAnonymousSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBFileSpec.m
+++ b/NCMBTests/NCMBTests/NCMBFileSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBInstallationSpec.m
+++ b/NCMBTests/NCMBTests/NCMBInstallationSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBInstallationSpec.m
+++ b/NCMBTests/NCMBTests/NCMBInstallationSpec.m
@@ -54,7 +54,7 @@ describe(@"NCMBInstallation", ^{
                                                        },
                                                @"applicationName" : @"aaaa",
                                                @"objectId" : @"EVMu2ne7bjzZhOW2",
-                                               @"sdkVersion" : @"3.1.2"
+                                               @"sdkVersion" : @"3.2.0"
                                                };
 
     NSDictionary *responseInstallation = @{@"channels" : @[

--- a/NCMBTests/NCMBTests/NCMBObjectSpec.m
+++ b/NCMBTests/NCMBTests/NCMBObjectSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBQuerySpec.m
+++ b/NCMBTests/NCMBTests/NCMBQuerySpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBRequestSpec.m
+++ b/NCMBTests/NCMBTests/NCMBRequestSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBRoleSpec.m
+++ b/NCMBTests/NCMBTests/NCMBRoleSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBScriptServiceSpec.m
+++ b/NCMBTests/NCMBTests/NCMBScriptServiceSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBScriptSpec.m
+++ b/NCMBTests/NCMBTests/NCMBScriptSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBSpec.m
+++ b/NCMBTests/NCMBTests/NCMBSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/NCMBTests/NCMBTests/NCMBUserSpec.m
+++ b/NCMBTests/NCMBTests/NCMBUserSpec.m
@@ -1,5 +1,5 @@
 /*
- Copyright 2017-2022 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
+ Copyright 2017-2023 FUJITSU CLOUD TECHNOLOGIES LIMITED All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@
 - iOS 13.x ～ iOS 16.x
 - Xcode 9.x ～ Xcode 14.x
 - armv7k, arm64, arm64e アーキテクチャ  
-(※2022年12月時点)  
+(※2023年4月時点)  
 - iOS/Xcodeのバージョンに依って対応が必要となる可能性があります。詳細はニフクラ mobile backendの[ドキュメント](https://mbaas.nifcloud.com/doc/current/)をご覧ください。
 
 ## テクニカルサポート窓口対応バージョン
@@ -36,7 +36,7 @@
 ※なお、mobile backend にて大規模な改修が行われた際は、1年半以内のSDKであっても対応出来ない場合がございます。<br>
 その際は[informationブログ](https://mbaas.nifcloud.com/info/)にてお知らせいたします。予めご了承ください。
 
-- v3.1.1 ～ (※2022年12月時点)
+- v3.1.1 ～ (※2023年4月時点)
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要(Summary)

- Bump version to v3.2.0
- Update README as of 2023/04
- Update LICENSE for 2023
